### PR TITLE
fix(be-keyword): address the issue #18

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,13 +3,13 @@ name: Unit Tests
 on:
   workflow_dispatch: {}
   push:
-    branches: [ develop ]
+    branches: [ main, develop ]
     paths:
       - 'backend/**'
       - 'src/**'
       - '!**.spec.js'
   pull_request:
-    branches: [ develop ]
+    branches: [ main, develop ]
     paths:
       - 'backend/**'
       - 'src/**'

--- a/backend/src/common/utils.ts
+++ b/backend/src/common/utils.ts
@@ -36,3 +36,10 @@ export const readCsvAsync = (buffer): Promise<string[]> => new Promise((resolve)
       // console.table(rows)
     })
 })
+
+/**
+ * return a standard queue job id
+ * @param {string} keywordId
+ * @returns {string}
+ */
+export const standardizeQueuedJobId = (keywordId: string): string => `${keywordId}-${new Date().getTime()}`

--- a/backend/src/constants/job-queue.ts
+++ b/backend/src/constants/job-queue.ts
@@ -1,2 +1,3 @@
 export const QUEUE_NAME = 'scraper'
+export const QUEUE_JOB_PREFIX = `bull:${QUEUE_NAME}`
 export const JOB_NAME = 'scrape'

--- a/backend/src/database/migration/1650590334078-keywordOmitJobQueueId.ts
+++ b/backend/src/database/migration/1650590334078-keywordOmitJobQueueId.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class keywordOmitJobQueueId1650590334078 implements MigrationInterface {
+    name = 'keywordOmitJobQueueId1650590334078'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "keyword" DROP COLUMN "jobQueueId"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "keyword" ADD "jobQueueId" character varying(30)`);
+    }
+
+}

--- a/backend/src/keyword/dto/keyword.result.dto.ts
+++ b/backend/src/keyword/dto/keyword.result.dto.ts
@@ -9,7 +9,7 @@ export class KeywordResultDto implements Readonly<KeywordResultDto> {
     name?: string
 
   @ApiProperty({ type: 'string', example: '2' })
-    jobQueueId?: string
+    queuedJobId?: string
 
   @ApiProperty({ type: 'boolean', example: false })
     isFinishedScraping?: boolean

--- a/backend/src/keyword/keyword.entity.ts
+++ b/backend/src/keyword/keyword.entity.ts
@@ -22,13 +22,6 @@ export class Keyword extends BaseEntity<Keyword> {
   })
     name: string
 
-  @ApiProperty({ type: 'string', example: '2' })
-  @Column('varchar', {
-    nullable: true,
-    length: 30
-  })
-    jobQueueId?: string
-
   @ApiProperty({ type: 'boolean', example: false })
   @Column({ type: 'boolean', default: false })
     isFinishedScraping?: boolean

--- a/backend/src/keyword/keyword.module.ts
+++ b/backend/src/keyword/keyword.module.ts
@@ -8,6 +8,7 @@ import { QUEUE_NAME } from '../constants/job-queue'
 import { KeywordService } from './keyword.service'
 import { KeywordController } from './keyword.controller'
 import { Keyword } from './keyword.entity'
+import { KeywordSubscriber } from './keyword.subscriber'
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { Keyword } from './keyword.entity'
   controllers: [KeywordController],
   providers: [
     KeywordService,
+    KeywordSubscriber,
     Mapper
   ],
   exports: [KeywordService]

--- a/backend/src/keyword/keyword.subscriber.ts
+++ b/backend/src/keyword/keyword.subscriber.ts
@@ -1,41 +1,39 @@
 import type {
   EntitySubscriberInterface,
   InsertEvent
-  // UpdateEvent
 } from 'typeorm'
-import { EventSubscriber } from 'typeorm'
+import { Connection, EventSubscriber } from 'typeorm'
 import { InjectQueue } from '@nestjs/bull'
 import { Queue } from 'bull'
 
 import { QUEUE_NAME, JOB_NAME } from '../constants/job-queue'
+import { standardizeQueuedJobId } from '../common/utils'
 
 import { Keyword } from './keyword.entity'
 
 @EventSubscriber()
 export class KeywordSubscriber implements EntitySubscriberInterface<Keyword> {
   constructor(
+    connection: Connection,
     @InjectQueue(QUEUE_NAME) private readonly scrapeQueue: Queue
-  ) {}
+  ) {
+    connection.subscribers.push(this)
+  }
 
   listenTo(): typeof Keyword {
     return Keyword
   }
 
-  async beforeInsert(event: InsertEvent<Keyword>) {
-    if (!event.entity.jobQueueId) {
-      console.log('this.scrapeQueue', this.scrapeQueue)
-      const jobData = await this.scrapeQueue.add(JOB_NAME, { keyword: event.entity.name })
-      // eslint-disable-next-line no-param-reassign
-      event.entity.jobQueueId = String(jobData.id) // NOTE: possibly be `${jobData.name}:${jobId}`
-    }
+  async afterInsert(event: InsertEvent<Keyword>) {
+    this.scrapeQueue.add(
+      JOB_NAME,
+      {
+        keywordId: event.entity.id,
+        keyword: event.entity.name
+      },
+      {
+        jobId: standardizeQueuedJobId(event.entity.id)
+      }
+    )
   }
-
-  // beforeUpdate(event: UpdateEvent<Keyword>): void {
-  //   // FIXME check event.databaseEntity.password
-  //   const entity = event.entity as Keyword
-
-  //   if (entity.password !== event.databaseEntity.password) {
-  //     entity.password = generateHash(entity.password!)
-  //   }
-  // }
 }


### PR DESCRIPTION
- decouple "queuedJobId" and "keyword" entity.
- use entity subscriber for "insert" listener on "keyword" entity for adding scraping jobs to queue.
- re-write related unit tests for the logic update.